### PR TITLE
add support for mgcv ocat models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,11 @@ Authors@R: c(
          role = c("aut")),
   person("Dungang", "Liu",
          email = "dungang.liu@uc.edu",
-         role = c("ctb"))
+         role = c("ctb")),
+  person("David", "Miller",
+         email = "dave.miller@bioss.ac.uk",
+         role = c("ctb"),
+         comment = c(ORCID = "0000-0002-9640-6755"))
   )
 Depends:
   R (>= 3.1)
@@ -51,5 +55,5 @@ URL: https://github.com/koalaverse/sure
 BugReports: https://github.com/koalaverse/sure/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -339,3 +339,9 @@ autoplot.polr <- autoplot.clm
 #'
 #' @export
 autoplot.vglm <- autoplot.clm
+
+
+#' @rdname autoplot.resid
+#'
+#' @export
+autoplot.gam <- autoplot.clm

--- a/R/sure.R
+++ b/R/sure.R
@@ -4,8 +4,8 @@
 #' The \code{sure} package provides surrogate-based residuals for fitted ordinal
 #' and general (e.g., binary) regression models of class
 #' \code{\link[ordinal]{clm}}, \code{\link[stats]{glm}}, \code{\link[rms]{lrm}},
-#' \code{\link[rms]{orm}}, \code{\link[MASS]{polr}}, or
-#' \code{\link[VGAM]{vglm}}.
+#' \code{\link[rms]{orm}}, \code{\link[MASS]{polr}},
+#' \code{\link[VGAM]{vglm}}, \code{\link[mgcv]{gam}}.
 #'
 #' The development version can be found on GitHub:
 #' \url{https://github.com/AFIT-R/sure}. As of right now, \code{sure} exports the

--- a/man/autoplot.resid.Rd
+++ b/man/autoplot.resid.Rd
@@ -8,6 +8,7 @@
 \alias{autoplot.orm}
 \alias{autoplot.polr}
 \alias{autoplot.vglm}
+\alias{autoplot.gam}
 \title{Residual plots}
 \usage{
 autoplot.resid(
@@ -167,6 +168,32 @@ autoplot.polr(
 )
 
 autoplot.vglm(
+  object,
+  what = c("qq", "fitted", "covariate"),
+  x = NULL,
+  fit = NULL,
+  distribution = qnorm,
+  ncol = NULL,
+  alpha = 1,
+  xlab = NULL,
+  color = "#444444",
+  shape = 19,
+  size = 2,
+  qqpoint.color = "#444444",
+  qqpoint.shape = 19,
+  qqpoint.size = 2,
+  qqline.color = "#888888",
+  qqline.linetype = "dashed",
+  qqline.size = 1,
+  smooth = TRUE,
+  smooth.color = "red",
+  smooth.linetype = 1,
+  smooth.size = 1,
+  fill = NULL,
+  ...
+)
+
+autoplot.gam(
   object,
   what = c("qq", "fitted", "covariate"),
   x = NULL,

--- a/man/sure.Rd
+++ b/man/sure.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/sure.R
 \docType{package}
 \name{sure}
+\alias{sure-package}
 \alias{sure}
 \title{sure: An R package for constructing surrogate-based residuals and diagnostics
 for ordinal and general regression models.}
@@ -9,8 +10,8 @@ for ordinal and general regression models.}
 The \code{sure} package provides surrogate-based residuals for fitted ordinal
 and general (e.g., binary) regression models of class
 \code{\link[ordinal]{clm}}, \code{\link[stats]{glm}}, \code{\link[rms]{lrm}},
-\code{\link[rms]{orm}}, \code{\link[MASS]{polr}}, or
-\code{\link[VGAM]{vglm}}.
+\code{\link[rms]{orm}}, \code{\link[MASS]{polr}},
+\code{\link[VGAM]{vglm}}, \code{\link[mgcv]{gam}}.
 }
 \details{
 The development version can be found on GitHub:
@@ -27,4 +28,28 @@ following functions:
 Liu, Dungang and Zhang, Heping. Residuals and Diagnostics for Ordinal
 Regression Models: A Surrogate Approach.
 \emph{Journal of the American Statistical Association} (accepted).
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/koalaverse/sure}
+  \item Report bugs at \url{https://github.com/koalaverse/sure/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Brandon Greenwell \email{greenwell.brandon@gmail.com} (\href{https://orcid.org/0000-0002-8120-0084}{ORCID})
+
+Authors:
+\itemize{
+  \item Brad Boehmke \email{bradleyboehmke@gmail.com} (\href{https://orcid.org/0000-0002-3611-8516}{ORCID})
+  \item Andrew McCarthy \email{andrew.mccarthy@theperducogroup.com}
+}
+
+Other contributors:
+\itemize{
+  \item Dungang Liu \email{dungang.liu@uc.edu} [contributor]
+  \item David Miller \email{dave.miller@bioss.ac.uk} (\href{https://orcid.org/0000-0002-9640-6755}{ORCID}) [contributor]
+}
+
 }


### PR DESCRIPTION
This patch should add support for the ordered categorical models available in `mgcv` for a while now via the `ocat` family. Mathematical details are in https://www.maths.ed.ac.uk/~swood34/gsm.pdf, but are not that different from the other models supported by `sure`.

I knocked this together fairly quickly and I think it works (comparison between the equivalent `polr` model for your `df1` seems about right, as do plots for some data I'm working on) but I may have missed some critical internal thing, not being fully immersed in the package details.

Hope this is useful and thanks for the package, it's very handy.